### PR TITLE
feat: 사용자 조회 api 구현

### DIFF
--- a/src/main/java/oz/yamyam_map/module/auth/jwt/JwtManager.java
+++ b/src/main/java/oz/yamyam_map/module/auth/jwt/JwtManager.java
@@ -78,10 +78,13 @@ public class JwtManager {
 	// jjwt : parser() 메서드가 parserBuilder()로 대체됨
 	// JWT 토큰에서 memberId 추출 (Body: 페이로드)
 	public Long getMemberId(String token) {
+
+		String bearerToken = token.substring(7);
+
 		return Long.parseLong(Jwts.parserBuilder()
 			.setSigningKey(secretKey)
 			.build()
-			.parseClaimsJws(token)
+			.parseClaimsJws(bearerToken)
 			.getBody()
 			.getSubject());
 	}

--- a/src/main/java/oz/yamyam_map/module/auth/jwt/JwtManager.java
+++ b/src/main/java/oz/yamyam_map/module/auth/jwt/JwtManager.java
@@ -28,7 +28,7 @@ public class JwtManager {
 	private final Key secretKey;
 
 	@Value("${jwt.expiration}")
-	private long tokenValidityInseconds;
+	private long tokenValidityInSeconds;
 
 	//jjwt: String secretKey -> Key 객체 방식으로 대체됨
 	public JwtManager(@Value("${jwt.secret}") String secret) {
@@ -48,7 +48,7 @@ public class JwtManager {
 		claims.put(CLAIM_ACCOUNT, account);
 
 		Date now = new Date();
-		Date validity = new Date(now.getTime() + tokenValidityInseconds * 1000);
+		Date validity = new Date(now.getTime() + tokenValidityInSeconds * 1000);
 
 		String token = Jwts.builder()
 			.setClaims(claims)
@@ -78,13 +78,10 @@ public class JwtManager {
 	// jjwt : parser() 메서드가 parserBuilder()로 대체됨
 	// JWT 토큰에서 memberId 추출 (Body: 페이로드)
 	public Long getMemberId(String token) {
-
-		String bearerToken = token.substring(7);
-
 		return Long.parseLong(Jwts.parserBuilder()
 			.setSigningKey(secretKey)
 			.build()
-			.parseClaimsJws(bearerToken)
+			.parseClaimsJws(token)
 			.getBody()
 			.getSubject());
 	}

--- a/src/main/java/oz/yamyam_map/module/member/controller/MemberController.java
+++ b/src/main/java/oz/yamyam_map/module/member/controller/MemberController.java
@@ -29,9 +29,9 @@ public class MemberController implements MemberControllerDocs {
 
 	@PostMapping
 	@ResponseStatus(ACCEPTED)
-	public BaseApiResponse<Void> signUp(
+	public BaseApiResponse<Void> postSignup(
 		@RequestBody @Valid MemberSignupReq request) {
-		memberService.signUp(request);
+		memberService.postSignup(request);
 		return BaseApiResponse.of(StatusCode.SIGN_UP_ACCEPTED);
 	}
 

--- a/src/main/java/oz/yamyam_map/module/member/controller/MemberController.java
+++ b/src/main/java/oz/yamyam_map/module/member/controller/MemberController.java
@@ -1,8 +1,6 @@
 package oz.yamyam_map.module.member.controller;
 
-import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.HttpStatus.*;
-import static oz.yamyam_map.common.code.StatusCode.*;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import oz.yamyam_map.common.BaseApiResponse;
+import oz.yamyam_map.common.code.StatusCode;
 import oz.yamyam_map.module.member.dto.request.MemberSignupReq;
 import oz.yamyam_map.module.member.dto.response.MemberDetailRes;
 import oz.yamyam_map.module.member.service.MemberService;
@@ -30,7 +29,7 @@ public class MemberController implements MemberControllerDocs {
 	@ResponseStatus(ACCEPTED)
 	public BaseApiResponse<Void> signUp(@RequestBody @Valid MemberSignupReq request) {
 		memberService.signUp(request);
-		return BaseApiResponse.of(SIGN_UP_ACCEPTED);
+		return BaseApiResponse.of(StatusCode.SIGN_UP_ACCEPTED);
 	}
 
 	@GetMapping("/detail")
@@ -39,7 +38,7 @@ public class MemberController implements MemberControllerDocs {
 
 		MemberDetailRes memberDetail = memberService.getMemberDetail(token.substring(7));
 
-		return BaseApiResponse.of(OK, memberDetail);
+		return BaseApiResponse.of(StatusCode.OK, memberDetail);
 	}
 
 }

--- a/src/main/java/oz/yamyam_map/module/member/controller/MemberController.java
+++ b/src/main/java/oz/yamyam_map/module/member/controller/MemberController.java
@@ -1,10 +1,13 @@
 package oz.yamyam_map.module.member.controller;
 
+import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.HttpStatus.*;
 import static oz.yamyam_map.common.code.StatusCode.*;
 
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -12,7 +15,8 @@ import org.springframework.web.bind.annotation.RestController;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import oz.yamyam_map.common.BaseApiResponse;
-import oz.yamyam_map.module.member.dto.MemberSignupReq;
+import oz.yamyam_map.module.member.dto.request.MemberSignupReq;
+import oz.yamyam_map.module.member.dto.response.MemberDetailRes;
 import oz.yamyam_map.module.member.service.MemberService;
 
 @RestController
@@ -27,6 +31,15 @@ public class MemberController implements MemberControllerDocs {
 	public BaseApiResponse<Void> signUp(@RequestBody @Valid MemberSignupReq request) {
 		memberService.signUp(request);
 		return BaseApiResponse.of(SIGN_UP_ACCEPTED);
+	}
+
+	@GetMapping("/detail")
+	@ResponseStatus(OK)
+	public BaseApiResponse<MemberDetailRes> getMemberDetail(@RequestHeader("Authorization") String token) {
+
+		MemberDetailRes memberDetail = memberService.getMemberDetail(token.substring(7));
+
+		return BaseApiResponse.of(OK, memberDetail);
 	}
 
 }

--- a/src/main/java/oz/yamyam_map/module/member/controller/MemberController.java
+++ b/src/main/java/oz/yamyam_map/module/member/controller/MemberController.java
@@ -14,6 +14,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import oz.yamyam_map.common.BaseApiResponse;
 import oz.yamyam_map.common.code.StatusCode;
+import oz.yamyam_map.module.auth.jwt.JwtManager;
 import oz.yamyam_map.module.member.dto.request.MemberSignupReq;
 import oz.yamyam_map.module.member.dto.response.MemberDetailRes;
 import oz.yamyam_map.module.member.service.MemberService;
@@ -24,19 +25,28 @@ import oz.yamyam_map.module.member.service.MemberService;
 public class MemberController implements MemberControllerDocs {
 
 	private final MemberService memberService;
+	private final JwtManager jwtManager;
 
 	@PostMapping
 	@ResponseStatus(ACCEPTED)
-	public BaseApiResponse<Void> signUp(@RequestBody @Valid MemberSignupReq request) {
+	public BaseApiResponse<Void> signUp(
+		@RequestBody @Valid MemberSignupReq request) {
 		memberService.signUp(request);
 		return BaseApiResponse.of(StatusCode.SIGN_UP_ACCEPTED);
 	}
 
 	@GetMapping("/detail")
 	@ResponseStatus(OK)
-	public BaseApiResponse<MemberDetailRes> getMemberDetail(@RequestHeader("Authorization") String token) {
+	public BaseApiResponse<MemberDetailRes> getMemberDetail(
+		@RequestHeader("Authorization") String token) {
 
-		MemberDetailRes memberDetail = memberService.getMemberDetail(token.substring(7));
+		// 토큰에서 "Bearer " 부분을 제거하고 JWT 토큰만 추출
+		String jwtToken = token.substring(7);
+
+		// JWT 토큰에서 사용자 ID를 추출
+		Long memberId = jwtManager.getMemberId(jwtToken);
+
+		MemberDetailRes memberDetail = memberService.getMemberDetail(memberId);
 
 		return BaseApiResponse.of(StatusCode.OK, memberDetail);
 	}

--- a/src/main/java/oz/yamyam_map/module/member/controller/MemberControllerDocs.java
+++ b/src/main/java/oz/yamyam_map/module/member/controller/MemberControllerDocs.java
@@ -5,7 +5,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import oz.yamyam_map.common.BaseApiResponse;
-import oz.yamyam_map.module.member.dto.MemberSignupReq;
+import oz.yamyam_map.module.member.dto.request.MemberSignupReq;
+import oz.yamyam_map.module.member.dto.response.MemberDetailRes;
 
 @Tag(name = "Member", description = "멤버 관련 API")
 public interface MemberControllerDocs {
@@ -16,4 +17,10 @@ public interface MemberControllerDocs {
 	})
 	BaseApiResponse<Void> signUp(MemberSignupReq request);
 
+	@Operation(summary = "사용자 정보 조회")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "요청이 성공했습니다.", useReturnTypeSchema = true),
+		@ApiResponse(responseCode = "404", description = "요청된 사용자를 찾을 수 없습니다.", useReturnTypeSchema = true)
+	})
+	BaseApiResponse<MemberDetailRes> getMemberDetail(String token);
 }

--- a/src/main/java/oz/yamyam_map/module/member/controller/MemberControllerDocs.java
+++ b/src/main/java/oz/yamyam_map/module/member/controller/MemberControllerDocs.java
@@ -15,7 +15,7 @@ public interface MemberControllerDocs {
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "202", description = "회원가입이 완료되었습니다.", useReturnTypeSchema = true)
 	})
-	BaseApiResponse<Void> signUp(MemberSignupReq request);
+	BaseApiResponse<Void> postSignup(MemberSignupReq request);
 
 	@Operation(summary = "사용자 정보 조회")
 	@ApiResponses(value = {

--- a/src/main/java/oz/yamyam_map/module/member/dto/MemberDetailRes.java
+++ b/src/main/java/oz/yamyam_map/module/member/dto/MemberDetailRes.java
@@ -1,0 +1,29 @@
+package oz.yamyam_map.module.member.dto;
+
+import lombok.Builder;
+import lombok.Value;
+import oz.yamyam_map.module.member.entity.Member;
+
+@Value
+@Builder
+public class MemberDetailRes {
+
+	Long id;
+	String account;
+
+	Double latitude;
+	Double longitude;
+	Boolean receiveRecommendations;
+
+	public static MemberDetailRes fromEntity(Member member) {
+
+		return MemberDetailRes.builder()
+			.id(member.getId())
+			.account(member.getAccount())
+			.latitude(member.getLatitude())
+			.longitude(member.getLongitude())
+			.receiveRecommendations(member.getReceiveRecommendations())
+			.build();
+
+	}
+}

--- a/src/main/java/oz/yamyam_map/module/member/dto/request/MemberSignupReq.java
+++ b/src/main/java/oz/yamyam_map/module/member/dto/request/MemberSignupReq.java
@@ -1,4 +1,4 @@
-package oz.yamyam_map.module.member.dto;
+package oz.yamyam_map.module.member.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/oz/yamyam_map/module/member/dto/response/MemberDetailRes.java
+++ b/src/main/java/oz/yamyam_map/module/member/dto/response/MemberDetailRes.java
@@ -1,4 +1,4 @@
-package oz.yamyam_map.module.member.dto;
+package oz.yamyam_map.module.member.dto.response;
 
 import lombok.Builder;
 import lombok.Value;

--- a/src/main/java/oz/yamyam_map/module/member/dto/response/MemberDetailRes.java
+++ b/src/main/java/oz/yamyam_map/module/member/dto/response/MemberDetailRes.java
@@ -1,5 +1,7 @@
 package oz.yamyam_map.module.member.dto.response;
 
+import org.locationtech.jts.geom.Point;
+
 import lombok.Builder;
 import lombok.Value;
 import oz.yamyam_map.module.member.entity.Member;
@@ -11,19 +13,24 @@ public class MemberDetailRes {
 	Long id;
 	String account;
 
+	// Point 형식으로 저장된 값을 위도와 경도로 지정해 클라이언트 측에서 값 확인에 어려움이 없도록 함.
 	Double latitude;
 	Double longitude;
+
 	Boolean receiveRecommendations;
 
 	public static MemberDetailRes fromEntity(Member member) {
 
+		Point location = member.getLocation();
+
 		return MemberDetailRes.builder()
 			.id(member.getId())
 			.account(member.getAccount())
-			.latitude(member.getLatitude())
-			.longitude(member.getLongitude())
+			.latitude(location != null ? location.getY() : null) // latitude
+			.longitude(location != null ? location.getX() : null) // longitude
 			.receiveRecommendations(member.getReceiveRecommendations())
 			.build();
 
 	}
+
 }

--- a/src/main/java/oz/yamyam_map/module/member/entity/Member.java
+++ b/src/main/java/oz/yamyam_map/module/member/entity/Member.java
@@ -1,5 +1,8 @@
 package oz.yamyam_map.module.member.entity;
 
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import org.locationtech.jts.geom.Point;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import jakarta.persistence.Column;
@@ -35,8 +38,9 @@ public class Member extends BaseEntity {
 	@Getter(AccessLevel.NONE)
 	private Password password;
 
-	private Double latitude;
-	private Double longitude;
+	@JdbcTypeCode(SqlTypes.GEOMETRY)
+	@Column(columnDefinition = "GEOMETRY")
+	private Point location;
 
 	private Boolean receiveRecommendations;
 

--- a/src/main/java/oz/yamyam_map/module/member/service/MemberService.java
+++ b/src/main/java/oz/yamyam_map/module/member/service/MemberService.java
@@ -22,7 +22,7 @@ public class MemberService {
 	private final MemberRepository memberRepository;
 
 	@Transactional
-	public void signUp(MemberSignupReq request) {
+	public void postSignup(MemberSignupReq request) {
 		// 계정 중복 검사
 		validateAccountUnique(request.account());
 

--- a/src/main/java/oz/yamyam_map/module/member/service/MemberService.java
+++ b/src/main/java/oz/yamyam_map/module/member/service/MemberService.java
@@ -7,9 +7,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import oz.yamyam_map.exception.custom.DataNotFoundException;
 import oz.yamyam_map.exception.custom.DuplicateResourceException;
 import oz.yamyam_map.module.auth.jwt.JwtManager;
-import oz.yamyam_map.module.member.dto.MemberSignupReq;
+import oz.yamyam_map.module.member.dto.request.MemberSignupReq;
+import oz.yamyam_map.module.member.dto.response.MemberDetailRes;
 import oz.yamyam_map.module.member.entity.Member;
 import oz.yamyam_map.module.member.repository.MemberRepository;
 
@@ -36,6 +38,17 @@ public class MemberService {
 		if (memberRepository.existsByAccount(account)) {
 			throw new DuplicateResourceException(DUPLICATE_ACCOUNT);
 		}
+	}
+
+	public MemberDetailRes getMemberDetail(String token) {
+
+		Long memberId = jwtManager.getMemberId(token);
+
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new DataNotFoundException(USER_NOT_FOUND));
+
+		return MemberDetailRes.fromEntity(member);
+
 	}
 
 }

--- a/src/main/java/oz/yamyam_map/module/member/service/MemberService.java
+++ b/src/main/java/oz/yamyam_map/module/member/service/MemberService.java
@@ -9,7 +9,6 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import oz.yamyam_map.exception.custom.DataNotFoundException;
 import oz.yamyam_map.exception.custom.DuplicateResourceException;
-import oz.yamyam_map.module.auth.jwt.JwtManager;
 import oz.yamyam_map.module.member.dto.request.MemberSignupReq;
 import oz.yamyam_map.module.member.dto.response.MemberDetailRes;
 import oz.yamyam_map.module.member.entity.Member;
@@ -21,7 +20,6 @@ public class MemberService {
 
 	private final PasswordEncoder passwordEncoder;
 	private final MemberRepository memberRepository;
-	private final JwtManager jwtManager;
 
 	@Transactional
 	public void signUp(MemberSignupReq request) {
@@ -40,9 +38,7 @@ public class MemberService {
 		}
 	}
 
-	public MemberDetailRes getMemberDetail(String token) {
-
-		Long memberId = jwtManager.getMemberId(token);
+	public MemberDetailRes getMemberDetail(Long memberId) {
 
 		Member member = memberRepository.findById(memberId)
 			.orElseThrow(() -> new DataNotFoundException(USER_NOT_FOUND));

--- a/src/test/java/oz/yamyam_map/module/member/service/MemberServiceTest.java
+++ b/src/test/java/oz/yamyam_map/module/member/service/MemberServiceTest.java
@@ -1,0 +1,73 @@
+package oz.yamyam_map.module.member.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static oz.yamyam_map.common.code.StatusCode.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import oz.yamyam_map.exception.custom.DataNotFoundException;
+import oz.yamyam_map.module.auth.jwt.JwtManager;
+import oz.yamyam_map.module.member.dto.response.MemberDetailRes;
+import oz.yamyam_map.module.member.entity.Member;
+import oz.yamyam_map.module.member.repository.MemberRepository;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+	private final PasswordEncoder passwordEncoder = mock(PasswordEncoder.class);
+
+	@Mock
+	private MemberRepository memberRepository;
+
+	@Mock
+	private JwtManager jwtManager;
+
+	@InjectMocks
+	private MemberService memberService;  // MemberService 클래스가 getMemberDetail 메서드를 포함한다고 가정
+
+	@Test
+	@DisplayName("유효한 토큰으로 회원 정보를 정상적으로 가져오는 경우")
+	void getMemberDetailSuccess() {
+		// Given
+		String token = "valid_token";
+		Long memberId = 1L;
+
+		Member member = Member.signUp("account", "password11!", passwordEncoder);
+		when(jwtManager.getMemberId(token)).thenReturn(memberId);
+		when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+
+		// When
+		MemberDetailRes result = memberService.getMemberDetail(token);
+
+		// Then
+		assertNotNull(result);
+		// 추가적으로 MemberDetailRes의 특정 필드값을 검증할 수 있습니다.
+	}
+
+	@Test
+	@DisplayName("회원이 존재하지 않을 때 DataNotFoundException 발생")
+	void getMemberDetailThrowsExceptionWhenMemberNotFound() {
+		// Given
+		String token = "valid_token";
+		Long memberId = 1L;
+
+		when(jwtManager.getMemberId(token)).thenReturn(memberId);
+		when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
+
+		// When & Then
+		DataNotFoundException exception = assertThrows(DataNotFoundException.class, () -> {
+			memberService.getMemberDetail(token);
+		});
+
+		assertEquals(USER_NOT_FOUND, exception.getStatusCode());
+	}
+}

--- a/src/test/java/oz/yamyam_map/module/member/service/MemberServiceTest.java
+++ b/src/test/java/oz/yamyam_map/module/member/service/MemberServiceTest.java
@@ -1,8 +1,8 @@
 package oz.yamyam_map.module.member.service;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
-import static oz.yamyam_map.common.code.StatusCode.*;
 
 import java.util.Optional;
 
@@ -15,21 +15,17 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import oz.yamyam_map.exception.custom.DataNotFoundException;
-import oz.yamyam_map.module.auth.jwt.JwtManager;
 import oz.yamyam_map.module.member.dto.response.MemberDetailRes;
 import oz.yamyam_map.module.member.entity.Member;
 import oz.yamyam_map.module.member.repository.MemberRepository;
 
 @ExtendWith(MockitoExtension.class)
-class MemberServiceTest {
+public class MemberServiceTest {
 
 	private final PasswordEncoder passwordEncoder = mock(PasswordEncoder.class);
 
 	@Mock
 	private MemberRepository memberRepository;
-
-	@Mock
-	private JwtManager jwtManager;
 
 	@InjectMocks
 	private MemberService memberService;
@@ -38,36 +34,34 @@ class MemberServiceTest {
 	@DisplayName("유효한 토큰으로 회원 정보를 정상적으로 가져오는 경우")
 	void getMemberDetailSuccess() {
 		// Given
-		String token = "valid_token";
 		Long memberId = 1L;
+		Member mockMember = Member.signUp("account", "password11!", passwordEncoder); // Mock Member 객체 생성
 
-		Member member = Member.signUp("account", "password11!", passwordEncoder);
-		when(jwtManager.getMemberId(token)).thenReturn(memberId);
-		when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+		when(memberRepository.findById(memberId)).thenReturn(Optional.of(mockMember));
 
 		// When
-		MemberDetailRes result = memberService.getMemberDetail(token);
+		MemberDetailRes result = memberService.getMemberDetail(memberId);
 
 		// Then
 		assertNotNull(result);
+		assertThat(result.getAccount()).isEqualTo("account");
 
+		verify(memberRepository, times(1)).findById(memberId);
 	}
 
 	@Test
 	@DisplayName("회원이 존재하지 않을 때 DataNotFoundException 발생")
 	void getMemberDetailThrowsExceptionWhenMemberNotFound() {
 		// Given
-		String token = "valid_token";
 		Long memberId = 1L;
 
-		when(jwtManager.getMemberId(token)).thenReturn(memberId);
 		when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
 
 		// When & Then
 		DataNotFoundException exception = assertThrows(DataNotFoundException.class, () ->
-			memberService.getMemberDetail(token)
+			memberService.getMemberDetail(memberId)
 		);
 
-		assertEquals(USER_NOT_FOUND, exception.getStatusCode());
+		verify(memberRepository, times(1)).findById(memberId);
 	}
 }

--- a/src/test/java/oz/yamyam_map/module/member/service/MemberServiceTest.java
+++ b/src/test/java/oz/yamyam_map/module/member/service/MemberServiceTest.java
@@ -64,9 +64,9 @@ class MemberServiceTest {
 		when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
 
 		// When & Then
-		DataNotFoundException exception = assertThrows(DataNotFoundException.class, () -> {
-			memberService.getMemberDetail(token);
-		});
+		DataNotFoundException exception = assertThrows(DataNotFoundException.class, () ->
+			memberService.getMemberDetail(token)
+		);
 
 		assertEquals(USER_NOT_FOUND, exception.getStatusCode());
 	}

--- a/src/test/java/oz/yamyam_map/module/member/service/MemberServiceTest.java
+++ b/src/test/java/oz/yamyam_map/module/member/service/MemberServiceTest.java
@@ -32,7 +32,7 @@ class MemberServiceTest {
 	private JwtManager jwtManager;
 
 	@InjectMocks
-	private MemberService memberService;  // MemberService 클래스가 getMemberDetail 메서드를 포함한다고 가정
+	private MemberService memberService;
 
 	@Test
 	@DisplayName("유효한 토큰으로 회원 정보를 정상적으로 가져오는 경우")
@@ -50,7 +50,7 @@ class MemberServiceTest {
 
 		// Then
 		assertNotNull(result);
-		// 추가적으로 MemberDetailRes의 특정 필드값을 검증할 수 있습니다.
+
 	}
 
 	@Test

--- a/src/test/java/oz/yamyam_map/module/member/service/MemberServiceTest.java
+++ b/src/test/java/oz/yamyam_map/module/member/service/MemberServiceTest.java
@@ -1,6 +1,5 @@
 package oz.yamyam_map.module.member.service;
 
-import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -31,7 +30,7 @@ public class MemberServiceTest {
 	private MemberService memberService;
 
 	@Test
-	@DisplayName("유효한 토큰으로 회원 정보를 정상적으로 가져오는 경우")
+	@DisplayName("[성공] 유효한 토큰으로 회원 정보를 정상적으로 가져오는 경우")
 	void getMemberDetailSuccess() {
 		// Given
 		Long memberId = 1L;
@@ -44,13 +43,13 @@ public class MemberServiceTest {
 
 		// Then
 		assertNotNull(result);
-		assertThat(result.getAccount()).isEqualTo("account");
+		assertEquals("account", result.getAccount());
 
 		verify(memberRepository, times(1)).findById(memberId);
 	}
 
 	@Test
-	@DisplayName("회원이 존재하지 않을 때 DataNotFoundException 발생")
+	@DisplayName("[실패] 회원이 존재하지 않을 때 DataNotFoundException 발생")
 	void getMemberDetailThrowsExceptionWhenMemberNotFound() {
 		// Given
 		Long memberId = 1L;

--- a/src/test/java/oz/yamyam_map/module/member/vo/PasswordTest.java
+++ b/src/test/java/oz/yamyam_map/module/member/vo/PasswordTest.java
@@ -22,9 +22,9 @@ class PasswordTest {
 	@ValueSource(strings = {"short", "123456789", "abcdefghij"})
 	@DisplayName("비밀번호가 조건을 충족하지 않을 때 예외 발생")
 	void invalidPasswordThrowsException(String invalidPassword) {
-		BadRequestException exception = assertThrows(BadRequestException.class, () -> {
-			Password.of(invalidPassword, passwordEncoder);
-		});
+		BadRequestException exception = assertThrows(BadRequestException.class, () ->
+			Password.of(invalidPassword, passwordEncoder)
+		);
 
 		// 여기서는 어떤 예외가 발생했는지 구체적으로 테스트할 수 있습니다.
 		// 예: 짧은 비밀번호 또는 단순한 비밀번호에 대한 예외 처리 확인
@@ -53,9 +53,9 @@ class PasswordTest {
 	@ValueSource(strings = {"aaa1234567", "bbb!@#1111", "ccc2222$$$"})
 	@DisplayName("비밀번호에 3회 이상 연속된 문자가 포함되면 예외 발생")
 	void repeatingCharactersPasswordThrowsException(String repeatingPassword) {
-		BadRequestException exception = assertThrows(BadRequestException.class, () -> {
-			Password.of(repeatingPassword, passwordEncoder);
-		});
+		BadRequestException exception = assertThrows(BadRequestException.class, () ->
+			Password.of(repeatingPassword, passwordEncoder)
+		);
 
 		assertEquals(PASSWORD_HAS_REPEATING_CHARACTER, exception.getStatusCode());
 	}

--- a/src/test/java/oz/yamyam_map/module/member/vo/PasswordTest.java
+++ b/src/test/java/oz/yamyam_map/module/member/vo/PasswordTest.java
@@ -1,0 +1,63 @@
+package oz.yamyam_map.module.member.vo;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static oz.yamyam_map.common.code.StatusCode.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import oz.yamyam_map.exception.custom.BadRequestException;
+
+@ExtendWith(MockitoExtension.class)
+class PasswordTest {
+
+	private final PasswordEncoder passwordEncoder = mock(PasswordEncoder.class);
+
+	@ParameterizedTest
+	@ValueSource(strings = {"short", "123456789", "abcdefghij"})
+	@DisplayName("비밀번호가 조건을 충족하지 않을 때 예외 발생")
+	void invalidPasswordThrowsException(String invalidPassword) {
+		BadRequestException exception = assertThrows(BadRequestException.class, () -> {
+			Password.of(invalidPassword, passwordEncoder);
+		});
+
+		// 여기서는 어떤 예외가 발생했는지 구체적으로 테스트할 수 있습니다.
+		// 예: 짧은 비밀번호 또는 단순한 비밀번호에 대한 예외 처리 확인
+		if (invalidPassword.length() < 10) {
+			assertEquals(SHORT_PASSWORD, exception.getStatusCode());
+		} else if (invalidPassword.matches("^\\d+$") || invalidPassword.matches("^[a-zA-Z]+$")) {
+			assertEquals(SIMPLE_PASSWORD, exception.getStatusCode());
+		} else {
+			fail("Unexpected exception for password: " + invalidPassword);
+		}
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"validPass123!", "AnotherPass456$", "Complex!@#789"})
+	@DisplayName("유효한 비밀번호는 예외 없이 생성되어야 한다")
+	void validPasswordDoesNotThrowException(String validPassword) {
+		when(passwordEncoder.encode(validPassword)).thenReturn("encodedPassword");
+
+		assertDoesNotThrow(() -> {
+			Password password = Password.of(validPassword, passwordEncoder);
+			assertEquals("encodedPassword", password.getValue());
+		});
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"aaa1234567", "bbb!@#1111", "ccc2222$$$"})
+	@DisplayName("비밀번호에 3회 이상 연속된 문자가 포함되면 예외 발생")
+	void repeatingCharactersPasswordThrowsException(String repeatingPassword) {
+		BadRequestException exception = assertThrows(BadRequestException.class, () -> {
+			Password.of(repeatingPassword, passwordEncoder);
+		});
+
+		assertEquals(PASSWORD_HAS_REPEATING_CHARACTER, exception.getStatusCode());
+	}
+
+}


### PR DESCRIPTION
## 🎟️ 관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #15 

## 👩‍💻 구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- [x] 응답 DTO 생성
- [x] Jwt Manager 의 memberId 추출 메서드 내 실제 토큰 추출 과정 추가
- [x] 컨트롤러 구현
- [x] 서비스 구현
- [x] 테스트 코드 작성
