### PR TITLE
시군구 목록 API 구현 및 point 직렬화 메서드 추가

### DIFF
--- a/src/main/java/oz/yamyam_map/common/util/GeoUtils.java
+++ b/src/main/java/oz/yamyam_map/common/util/GeoUtils.java
@@ -1,9 +1,16 @@
 package oz.yamyam_map.common.util;
 
+import java.io.IOException;
+
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.PrecisionModel;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
 public class GeoUtils {
 
 	private static final int SRID_WGS84 = 4326;
@@ -27,5 +34,18 @@ public class GeoUtils {
 	 **/
 	private static double roundToSixDecimals(double value) {
 		return Math.round(value * SCALING_FACTOR) / SCALING_FACTOR;
+	}
+
+	/**
+	 * Point 객체를 JSON으로 직렬화하는 메서드 (응답 시 간단한 x,y 형태로 보내기 위해)
+	 **/
+	public static class PointSerializer extends JsonSerializer<Point> {
+		@Override
+		public void serialize(Point value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+			gen.writeStartObject();
+			gen.writeNumberField("x", roundToSixDecimals(value.getX()));
+			gen.writeNumberField("y", roundToSixDecimals(value.getY()));
+			gen.writeEndObject();
+		}
 	}
 }

--- a/src/main/java/oz/yamyam_map/module/region/controller/RegionController.java
+++ b/src/main/java/oz/yamyam_map/module/region/controller/RegionController.java
@@ -6,6 +6,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
+import oz.yamyam_map.common.BaseApiResponse;
+import oz.yamyam_map.common.code.StatusCode;
 import oz.yamyam_map.module.region.dto.response.RegionResponse;
 import oz.yamyam_map.module.region.service.RegionSerivce;
 
@@ -18,9 +20,8 @@ public class RegionController {
 
 	// 시군구 목록 api
 	@GetMapping
-	public ResponseEntity<RegionResponse> getRegions() {
+	public BaseApiResponse<RegionResponse> getRegions() {
 		RegionResponse response = regionSerivce.getRegionResponse();
-		return ResponseEntity.ok(response);
+		return BaseApiResponse.of(StatusCode.OK, response);
 	}
-
 }

--- a/src/main/java/oz/yamyam_map/module/region/controller/RegionController.java
+++ b/src/main/java/oz/yamyam_map/module/region/controller/RegionController.java
@@ -20,7 +20,7 @@ public class RegionController implements RegionControllerDocs {
 	// 시군구 목록 api
 	@GetMapping
 	public BaseApiResponse<RegionResponse> getRegions() {
-		RegionResponse response = regionSerivce.getRegionResponse();
+		RegionResponse response = regionSerivce.getRegions();
 		return BaseApiResponse.of(StatusCode.OK, response);
 	}
 }

--- a/src/main/java/oz/yamyam_map/module/region/controller/RegionController.java
+++ b/src/main/java/oz/yamyam_map/module/region/controller/RegionController.java
@@ -1,6 +1,5 @@
 package oz.yamyam_map.module.region.controller;
 
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,7 +13,7 @@ import oz.yamyam_map.module.region.service.RegionSerivce;
 @RestController
 @RequestMapping("/api/region")
 @RequiredArgsConstructor
-public class RegionController {
+public class RegionController implements RegionControllerDocs {
 
 	private final RegionSerivce regionSerivce;
 

--- a/src/main/java/oz/yamyam_map/module/region/controller/RegionController.java
+++ b/src/main/java/oz/yamyam_map/module/region/controller/RegionController.java
@@ -1,0 +1,26 @@
+package oz.yamyam_map.module.region.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import oz.yamyam_map.module.region.dto.response.RegionResponse;
+import oz.yamyam_map.module.region.service.RegionSerivce;
+
+@RestController
+@RequestMapping("/api/region")
+@RequiredArgsConstructor
+public class RegionController {
+
+	private final RegionSerivce regionSerivce;
+
+	// 시군구 목록 api
+	@GetMapping
+	public ResponseEntity<RegionResponse> getRegions() {
+		RegionResponse response = regionSerivce.getRegionResponse();
+		return ResponseEntity.ok(response);
+	}
+
+}

--- a/src/main/java/oz/yamyam_map/module/region/controller/RegionControllerDocs.java
+++ b/src/main/java/oz/yamyam_map/module/region/controller/RegionControllerDocs.java
@@ -1,0 +1,20 @@
+package oz.yamyam_map.module.region.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import oz.yamyam_map.common.BaseApiResponse;
+import oz.yamyam_map.module.region.dto.response.RegionResponse;
+
+@Tag(name = "시군구", description = "시군구 조회 api")
+public interface RegionControllerDocs {
+
+	@Operation(summary = "모든 지역과 해당 시군구 목록 조회", description = "도/시와 그에 해당하는 시군구 목록을 반환합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "요청이 성공했습니다."),
+		@ApiResponse(responseCode = "500", description = "내부 서버 오류가 발생했습니다.")
+	})
+	BaseApiResponse<RegionResponse> getRegions();
+
+}

--- a/src/main/java/oz/yamyam_map/module/region/controller/RegionControllerDocs.java
+++ b/src/main/java/oz/yamyam_map/module/region/controller/RegionControllerDocs.java
@@ -12,9 +12,7 @@ public interface RegionControllerDocs {
 
 	@Operation(summary = "모든 지역과 해당 시군구 목록 조회", description = "도/시와 그에 해당하는 시군구 목록을 반환합니다.")
 	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "요청이 성공했습니다."),
-		@ApiResponse(responseCode = "500", description = "내부 서버 오류가 발생했습니다.")
+		@ApiResponse(responseCode = "200", description = "요청이 성공했습니다.")
 	})
 	BaseApiResponse<RegionResponse> getRegions();
-
 }

--- a/src/main/java/oz/yamyam_map/module/region/dto/response/RegionResponse.java
+++ b/src/main/java/oz/yamyam_map/module/region/dto/response/RegionResponse.java
@@ -23,7 +23,7 @@ public class RegionResponse {
 
 	// 시군구 정보(id, 위치) 같이 뿌려주기 위한 CityDistrict InnerClass
 	@Getter
-	@AllArgsConstructor(access = AccessLevel.PRIVATE)
+	@AllArgsConstructor
 	public static class CityDistrict {
 		private Long id;
 		private String name;

--- a/src/main/java/oz/yamyam_map/module/region/dto/response/RegionResponse.java
+++ b/src/main/java/oz/yamyam_map/module/region/dto/response/RegionResponse.java
@@ -12,6 +12,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import oz.yamyam_map.common.util.GeoUtils;
+import oz.yamyam_map.module.region.entity.Region;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -36,5 +37,13 @@ public class RegionResponse {
 		@Schema(description = "Location in x, y 좌표", example = "{\"x\": 127.028, \"y\": 37.496}")
 		@JsonSerialize(using = GeoUtils.PointSerializer.class)
 		private Point location;
+
+		public static CityDistrict newCityDistrict(Region region) {
+			return new CityDistrict(
+				region.getId(),
+				region.getCityDistrict(),
+				region.getLocation()
+			);
+		}
 	}
 }

--- a/src/main/java/oz/yamyam_map/module/region/dto/response/RegionResponse.java
+++ b/src/main/java/oz/yamyam_map/module/region/dto/response/RegionResponse.java
@@ -5,10 +5,13 @@ import java.util.Map;
 
 import org.locationtech.jts.geom.Point;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import oz.yamyam_map.common.util.GeoUtils;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -29,6 +32,9 @@ public class RegionResponse {
 	public static class CityDistrict {
 		private Long id;
 		private String name;
+
+		@Schema(description = "Location in x, y 좌표", example = "{\"x\": 127.028, \"y\": 37.496}")
+		@JsonSerialize(using = GeoUtils.PointSerializer.class)
 		private Point location;
 	}
 }

--- a/src/main/java/oz/yamyam_map/module/region/dto/response/RegionResponse.java
+++ b/src/main/java/oz/yamyam_map/module/region/dto/response/RegionResponse.java
@@ -1,0 +1,24 @@
+package oz.yamyam_map.module.region.dto.response;
+
+import java.util.List;
+import java.util.Map;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class RegionResponse {
+
+	@Schema(description = "시/도 리스트")
+	private List<String> provinces;
+
+	@Schema(description = "각 시/도에 해당하는 시군구 리스트")
+	private Map<String, List<String>> cityDistricts;
+
+	public static RegionResponse of(List<String> provinces, Map<String, List<String>> cityDistricts ) {
+		return new RegionResponse(provinces, cityDistricts);
+	}
+}

--- a/src/main/java/oz/yamyam_map/module/region/dto/response/RegionResponse.java
+++ b/src/main/java/oz/yamyam_map/module/region/dto/response/RegionResponse.java
@@ -12,6 +12,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Schema(description = "시군구 조회 API의 응답 객체")
 public class RegionResponse {
 
 	@Schema(description = "시/도 별로 그룹화 한 시군구 리스트")
@@ -24,6 +25,7 @@ public class RegionResponse {
 	// 시군구 정보(id, 위치) 같이 뿌려주기 위한 CityDistrict InnerClass
 	@Getter
 	@AllArgsConstructor
+	@Schema(description = "시군구 데이터")
 	public static class CityDistrict {
 		private Long id;
 		private String name;

--- a/src/main/java/oz/yamyam_map/module/region/dto/response/RegionResponse.java
+++ b/src/main/java/oz/yamyam_map/module/region/dto/response/RegionResponse.java
@@ -15,13 +15,13 @@ import lombok.Getter;
 public class RegionResponse {
 
 	@Schema(description = "시/도 별로 그룹화 한 시군구 리스트")
-	private Map<String, List<String>> cityDistricts;
+	private Map<String, List<CityDistrict>> cityDistricts;
 
-	public static RegionResponse of(Map<String, List<String>> cityDistricts) {
+	public static RegionResponse of(Map<String, List<CityDistrict>> cityDistricts) {
 		return new RegionResponse(cityDistricts);
 	}
 
-	// 시군구 정보 같이 뿌려주기 위한 CityDistrict InnerClass
+	// 시군구 정보(id, 위치) 같이 뿌려주기 위한 CityDistrict InnerClass
 	@Getter
 	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class CityDistrict {

--- a/src/main/java/oz/yamyam_map/module/region/dto/response/RegionResponse.java
+++ b/src/main/java/oz/yamyam_map/module/region/dto/response/RegionResponse.java
@@ -3,6 +3,8 @@ package oz.yamyam_map.module.region.dto.response;
 import java.util.List;
 import java.util.Map;
 
+import org.locationtech.jts.geom.Point;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -12,13 +14,19 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class RegionResponse {
 
-	@Schema(description = "시/도 리스트")
-	private List<String> provinces;
-
-	@Schema(description = "각 시/도에 해당하는 시군구 리스트")
+	@Schema(description = "시/도 별로 그룹화 한 시군구 리스트")
 	private Map<String, List<String>> cityDistricts;
 
-	public static RegionResponse of(List<String> provinces, Map<String, List<String>> cityDistricts ) {
-		return new RegionResponse(provinces, cityDistricts);
+	public static RegionResponse of(Map<String, List<String>> cityDistricts) {
+		return new RegionResponse(cityDistricts);
+	}
+
+	// 시군구 정보 같이 뿌려주기 위한 CityDistrict InnerClass
+	@Getter
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
+	public static class CityDistrict {
+		private Long id;
+		private String name;
+		private Point location;
 	}
 }

--- a/src/main/java/oz/yamyam_map/module/region/entity/Region.java
+++ b/src/main/java/oz/yamyam_map/module/region/entity/Region.java
@@ -30,7 +30,7 @@ public class Region {
 	@Column(nullable = false)
 	private String cityDistrict;
 
-	@Column(nullable = false, columnDefinition = "POINT")
+	@Column(nullable = false, columnDefinition = "Point")
 	private Point location;
 
 }

--- a/src/main/java/oz/yamyam_map/module/region/entity/Region.java
+++ b/src/main/java/oz/yamyam_map/module/region/entity/Region.java
@@ -10,6 +10,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
 import org.locationtech.jts.geom.Point;
 
 @Entity
@@ -21,7 +22,7 @@ public class Region {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name="region_id")
+	@Column(name = "region_id")
 	private Long id;
 
 	@Column(nullable = false)

--- a/src/main/java/oz/yamyam_map/module/region/entity/Region.java
+++ b/src/main/java/oz/yamyam_map/module/region/entity/Region.java
@@ -22,7 +22,6 @@ public class Region {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "region_id")
 	private Long id;
 
 	@Column(nullable = false)

--- a/src/main/java/oz/yamyam_map/module/region/repository/RegionRepository.java
+++ b/src/main/java/oz/yamyam_map/module/region/repository/RegionRepository.java
@@ -1,0 +1,22 @@
+package oz.yamyam_map.module.region.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import oz.yamyam_map.module.region.entity.Region;
+
+@Repository
+public interface RegionRepository extends JpaRepository<Region, Long> {
+
+	// 도/시 목록 중복 없이 가져옴
+	@Query("SELECT DISTINCT r.province FROM region r")
+	List<String> findProvinces();
+
+	// 각 도/시의 시군구 목록 조회
+	@Query("SELECT r.cityDistrict FROM region r WHERE r.province = :province")
+	List<String> findCityDistrictByProvince(@Param("province") String province);
+}

--- a/src/main/java/oz/yamyam_map/module/region/repository/RegionRepository.java
+++ b/src/main/java/oz/yamyam_map/module/region/repository/RegionRepository.java
@@ -3,8 +3,6 @@ package oz.yamyam_map.module.region.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import oz.yamyam_map.module.region.entity.Region;
@@ -12,11 +10,4 @@ import oz.yamyam_map.module.region.entity.Region;
 @Repository
 public interface RegionRepository extends JpaRepository<Region, Long> {
 
-	// 도/시 목록 중복 없이 가져옴
-	@Query("SELECT DISTINCT r.province FROM region r")
-	List<String> findProvinces();
-
-	// 각 도/시의 시군구 목록 조회
-	@Query("SELECT r.cityDistrict FROM region r WHERE r.province = :province")
-	List<String> findCityDistrictByProvince(@Param("province") String province);
 }

--- a/src/main/java/oz/yamyam_map/module/region/service/RegionSerivce.java
+++ b/src/main/java/oz/yamyam_map/module/region/service/RegionSerivce.java
@@ -21,7 +21,7 @@ public class RegionSerivce {
 	private final RegionRepository regionRepository;
 
 	// 시/도와 시/도별 시군구 목록 가져오기
-	public RegionResponse getRegions() {	
+	public RegionResponse getRegions() {
 		List<Region> regions = regionRepository.findAll();
 
 		if (regions.isEmpty()) {
@@ -33,19 +33,11 @@ public class RegionSerivce {
 			.collect(Collectors.groupingBy(
 				Region::getProvince,    // 도/시로 그룹화
 				Collectors.mapping(
-					this::convertToCityDistrict,
+					RegionResponse.CityDistrict::newCityDistrict,
 					Collectors.toList()
 				)
 			));
 
 		return RegionResponse.of(cityRestricts);
-	}
-
-	private RegionResponse.CityDistrict convertToCityDistrict(Region region) {
-		return new RegionResponse.CityDistrict(
-			region.getId(),
-			region.getCityDistrict(),
-			region.getLocation()
-		);
 	}
 }

--- a/src/main/java/oz/yamyam_map/module/region/service/RegionSerivce.java
+++ b/src/main/java/oz/yamyam_map/module/region/service/RegionSerivce.java
@@ -34,7 +34,7 @@ public class RegionSerivce {
 				Region::getProvince,    // 도/시로 그룹화
 				Collectors.mapping(
 					this::convertToCityDistrict,
-					Collectors.toList()		// CityDistrict들을 List로 모으기
+					Collectors.toList()
 				)
 			));
 

--- a/src/main/java/oz/yamyam_map/module/region/service/RegionSerivce.java
+++ b/src/main/java/oz/yamyam_map/module/region/service/RegionSerivce.java
@@ -1,5 +1,6 @@
 package oz.yamyam_map.module.region.service;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -22,6 +23,10 @@ public class RegionSerivce {
 	// 시/도와 시/도별 시군구 목록 가져오기
 	public RegionResponse getRegionResponse() {
 		List<Region> regions = regionRepository.findAll();
+
+		if (regions.isEmpty()) {
+			return RegionResponse.of(Collections.emptyMap());
+		}
 
 		// key:도/시, value:해당 도/시의 시군구 리스트
 		Map<String, List<RegionResponse.CityDistrict>> cityRestricts = regions.stream()

--- a/src/main/java/oz/yamyam_map/module/region/service/RegionSerivce.java
+++ b/src/main/java/oz/yamyam_map/module/region/service/RegionSerivce.java
@@ -1,0 +1,46 @@
+package oz.yamyam_map.module.region.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import oz.yamyam_map.module.region.dto.response.RegionResponse;
+import oz.yamyam_map.module.region.entity.Region;
+import oz.yamyam_map.module.region.repository.RegionRepository;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class RegionSerivce {
+
+	private final RegionRepository regionRepository;
+
+	// 시/도와 시/도별 시군구 목록 가져오기
+	public RegionResponse getRegionResponse() {
+		List<Region> regions = regionRepository.findAll();
+
+		// key:도/시, value:해당 도/시의 시군구 리스트
+		Map<String, List<RegionResponse.CityDistrict>> cityRestricts = regions.stream()
+			.collect(Collectors.groupingBy(
+				Region::getProvince,    // 도/시로 그룹화
+				Collectors.mapping(
+					this::convertToCityDistrict,
+					Collectors.toList()		// CityDistrict들을 List로 모으기
+				)
+			));
+
+		return RegionResponse.of(cityRestricts);
+	}
+
+	private RegionResponse.CityDistrict convertToCityDistrict(Region region) {
+		return new RegionResponse.CityDistrict(
+			region.getId(),
+			region.getCityDistrict(),
+			region.getLocation()
+		);
+	}
+}


### PR DESCRIPTION
## 🎟️ 관련 이슈
Fixes #27 

## 👩‍💻 구현 내용
- [x] 시군구 목록 API 구현
- [x] swagger 문서화
- [x] Point 직렬화 메서드 GeoUtils에 추가

## 💬 코멘트
`location`을 Point 타입 그대로 보내니 응답이 너무 복잡해서 작성하신 `GeoUtils` 클래스 안에 내부 클래스로 `JsonSerializer<Point>` 추가하고`@JsonSerialize` 붙여주었습니다. 
사진처럼 postman 테스트하면 x, y로 잘 보내지는데 swagger은 지원이 안되는지 반영 안되어서 그냥 example 값 추가했습니다!
![image (1)](https://github.com/user-attachments/assets/59bcbf75-bdbf-41ca-aa01-de5f0091a979)
point 반환하실 일이 있다면 재사용하시면 될 것 같아요

그리고 테스트 하면서 db에 값 넣으려다보니 mysql8부터는 이전까지랑은 다르게 
![image](https://github.com/user-attachments/assets/5214d893-2709-4cf4-8523-e0ed9ffd7c16)
이렇게 (위도, 경도) 순으로 넣어야만 인서트가 되더라구요!
잠시 혼란스러웠는데 jts에서 가져올 때는 제대로 (x 경도, y 위도)로 매핑되는 것 같습니다!


## 💭 고려한 점
사용자가 시군구 선택해서 그 반경 맛집 불러올 때, 내 주변 맛집 보기랑 똑같이 파라미터 받아오게 하려고 목록에 도/시와 좌표 포함한 시군구 객체를 한번에 넣었습니다.