### PR TITLE
전반적인 배치 패키지 구조 설계

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
 
     // H2
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/oz/yamyam_map/batch/config/BatchConfig.java
+++ b/src/main/java/oz/yamyam_map/batch/config/BatchConfig.java
@@ -1,0 +1,19 @@
+package oz.yamyam_map.batch.config;
+
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import jakarta.persistence.EntityManagerFactory;
+
+@Configuration
+@EnableBatchProcessing // 배치 기능 활성화
+public class BatchConfig {
+	
+	@Bean
+	public PlatformTransactionManager transactionManager(EntityManagerFactory entityManagerFactory) {
+		return new JpaTransactionManager(entityManagerFactory);
+	}
+}

--- a/src/main/java/oz/yamyam_map/batch/config/SeoulDataPipelineJobConfig.java
+++ b/src/main/java/oz/yamyam_map/batch/config/SeoulDataPipelineJobConfig.java
@@ -1,0 +1,43 @@
+package oz.yamyam_map.batch.config;
+
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import lombok.RequiredArgsConstructor;
+import oz.yamyam_map.batch.domain.RowSeoulRestaurant;
+import oz.yamyam_map.batch.dto.SeoulRestaurantDto;
+
+@Configuration
+@RequiredArgsConstructor
+public class SeoulDataPipelineJobConfig {
+
+	/**
+	 * Step 1. OpenApi로 받아 온 데이터를 row table에 저장
+	 * RowSeoulDataApiReader: HTTP 요청을 보내고 데이터를 받아오는 객체
+	 * RowSeoulDataProcessor: 추가/변경된 데이터만 필터링하는 객체
+	 * RowSeoulDataWriter: 추가/변경 된 데이터를 row table에 반영하는 객체
+	 */
+	@Bean
+	public Step rowSeoulDataStoreStep(
+		JobRepository jobRepository,
+		PlatformTransactionManager platformTransactionManager,
+		ItemReader<SeoulRestaurantDto> rowSeoulDataApiReader,
+		ItemProcessor<SeoulRestaurantDto, RowSeoulRestaurant> rowSeoulDataProcessor,
+		ItemWriter<RowSeoulRestaurant> rowSeoulDataWriter
+	) {
+		return new StepBuilder("RowSeoulDataStoreStep", jobRepository)
+			.<SeoulRestaurantDto, RowSeoulRestaurant>chunk(100, platformTransactionManager)
+			.reader(rowSeoulDataApiReader)
+			.processor(rowSeoulDataProcessor)
+			.writer(rowSeoulDataWriter)
+			.build();
+	}
+
+}

--- a/src/main/java/oz/yamyam_map/batch/config/SeoulDataPipelineJobConfig.java
+++ b/src/main/java/oz/yamyam_map/batch/config/SeoulDataPipelineJobConfig.java
@@ -1,6 +1,8 @@
 package oz.yamyam_map.batch.config;
 
+import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.batch.item.ItemProcessor;
@@ -18,6 +20,14 @@ import oz.yamyam_map.module.restaurant.entity.Restaurant;
 @Configuration
 @RequiredArgsConstructor
 public class SeoulDataPipelineJobConfig {
+
+	@Bean
+	public Job seoulDataPipelineJob(JobRepository jobRepository, Step rowSeoulDataStoreStep, Step seoulDataUpdateStep) {
+		return new JobBuilder("SeoulDataPipelineJob", jobRepository)
+			.start(rowSeoulDataStoreStep)
+			.next(seoulDataUpdateStep)
+			.build();
+	}
 
 	/**
 	 * Step 1. OpenApi로 받아 온 데이터를 row table에 저장

--- a/src/main/java/oz/yamyam_map/batch/config/SeoulDataPipelineJobConfig.java
+++ b/src/main/java/oz/yamyam_map/batch/config/SeoulDataPipelineJobConfig.java
@@ -14,6 +14,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
 
 import lombok.RequiredArgsConstructor;
+import oz.yamyam_map.batch.config.properties.SeoulDataPipelineProperties;
 import oz.yamyam_map.batch.domain.RowSeoulRestaurant;
 import oz.yamyam_map.batch.dto.SeoulRestaurantDto;
 import oz.yamyam_map.module.restaurant.entity.Restaurant;

--- a/src/main/java/oz/yamyam_map/batch/config/SeoulDataPipelineJobConfig.java
+++ b/src/main/java/oz/yamyam_map/batch/config/SeoulDataPipelineJobConfig.java
@@ -8,6 +8,7 @@ import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.ItemWriter;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -19,7 +20,10 @@ import oz.yamyam_map.module.restaurant.entity.Restaurant;
 
 @Configuration
 @RequiredArgsConstructor
+@ConfigurationPropertiesScan
 public class SeoulDataPipelineJobConfig {
+
+	private final SeoulDataPipelineProperties properties;
 
 	@Bean
 	public Job seoulDataPipelineJob(JobRepository jobRepository, Step rowSeoulDataStoreStep, Step seoulDataUpdateStep) {
@@ -44,7 +48,7 @@ public class SeoulDataPipelineJobConfig {
 		ItemWriter<RowSeoulRestaurant> rowSeoulDataWriter
 	) {
 		return new StepBuilder("RowSeoulDataStoreStep", jobRepository)
-			.<SeoulRestaurantDto, RowSeoulRestaurant>chunk(100, platformTransactionManager)
+			.<SeoulRestaurantDto, RowSeoulRestaurant>chunk(properties.chunkSize(), platformTransactionManager)
 			.reader(rowSeoulDataApiReader)
 			.processor(rowSeoulDataProcessor)
 			.writer(rowSeoulDataWriter)
@@ -66,7 +70,7 @@ public class SeoulDataPipelineJobConfig {
 		ItemWriter<Restaurant> seoulDataWriter
 	) {
 		return new StepBuilder("SeoulDataUpdateStep", jobRepository)
-			.<RowSeoulRestaurant, Restaurant>chunk(100, platformTransactionManager)
+			.<RowSeoulRestaurant, Restaurant>chunk(properties.chunkSize(), platformTransactionManager)
 			.reader(rowSeoulDataDbReader)
 			.processor(seoulDataProcessor)
 			.writer(seoulDataWriter)

--- a/src/main/java/oz/yamyam_map/batch/config/SeoulDataPipelineProperties.java
+++ b/src/main/java/oz/yamyam_map/batch/config/SeoulDataPipelineProperties.java
@@ -1,0 +1,10 @@
+package oz.yamyam_map.batch.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("batch.seoul")
+public record SeoulDataPipelineProperties(
+	String authKey,
+	int chunkSize
+) {
+}

--- a/src/main/java/oz/yamyam_map/batch/config/properties/SeoulDataPipelineProperties.java
+++ b/src/main/java/oz/yamyam_map/batch/config/properties/SeoulDataPipelineProperties.java
@@ -1,4 +1,4 @@
-package oz.yamyam_map.batch.config;
+package oz.yamyam_map.batch.config.properties;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 

--- a/src/main/java/oz/yamyam_map/batch/domain/RowSeoulRestaurant.java
+++ b/src/main/java/oz/yamyam_map/batch/domain/RowSeoulRestaurant.java
@@ -1,0 +1,171 @@
+package oz.yamyam_map.batch.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import oz.yamyam_map.batch.dto.SeoulRestaurantDto;
+import oz.yamyam_map.common.entity.BaseEntity;
+
+@Entity
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RowSeoulRestaurant extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String opnsfteamcode; // 개방자치단체코드
+
+	@Column(nullable = false, unique = true)
+	private String mgtno; // 관리번호
+
+	private String apvpermymd; // 인허가일자
+
+	private String apvcancelymd; // 인허가취소일자
+
+	private String trdstategbn; // 영업상태코드
+
+	private String trdstatenm; // 영업상태명
+
+	private String dtlstategbn; // 상세영업상태코드
+
+	private String dtlstatenm; // 상세영업상태명
+
+	private String dcbymd; // 폐업일자
+
+	private String clgstdt; // 휴업시작일자
+
+	private String clgenddt; // 휴업종료일자
+
+	private String ropnymd; // 재개업일자
+
+	private String sitetel; // 전화번호
+
+	private String sitearea; // 소재지면적
+
+	private String sitepostno; // 소재지우편번호
+
+	private String sitewhladdr; // 지번주소
+
+	private String rdnwhladdr; // 도로명주소
+
+	private String rdnpostno; // 도로명우편번호
+
+	private String bplcnm; // 사업장명
+
+	private String lastmodts; // 최종수정일자
+
+	private String updategbn; // 데이터갱신구분
+
+	private String updatedt; // 데이터갱신일자
+
+	private String uptaenm; // 업태구분명
+
+	private String x; // 좌표정보(X)
+
+	private String y; // 좌표정보(Y)
+
+	private String sntuptaenm; // 위생업태명
+
+	private String maneipcnt; // 남성종사자수
+
+	private String wmeipcnt; // 여성종사자수
+
+	private String trdpjubnsenm; // 영업장주변구분명
+
+	private String lvsenm; // 등급구분명
+
+	private String wtrsplyfacilsenm; // 급수시설구분명
+
+	private String totepnum; // 총인원
+
+	private String hoffepcnt; // 본사종업원수
+
+	private String fctyowkepcnt; // 공장사무직종업원수
+
+	private String fctysiljobepcnt; // 공장판매직종업원수
+
+	private String fctypdtjobepcnt; // 공장생산직종업원수
+
+	private String bdngownsenm; // 건물소유구분명
+
+	private String isream; // 보증액
+
+	private String monam; // 월세액
+
+	private String multusnupsoyn; // 다중이용업소여부
+
+	private String faciltotscp; // 시설총규모
+
+	private String jtupsoasgnno; // 전통업소지정번호
+
+	private String jtupsomainedf; // 전통업소주된음식
+
+	private String homepage; // 홈페이지
+
+	private String hash; // 변경 감지를 위한 해시값
+
+	public static RowSeoulRestaurant of(SeoulRestaurantDto dto) {
+		return RowSeoulRestaurant.builder()
+			.opnsfteamcode(dto.opnsfteamcode())
+			.mgtno(dto.mgtno())
+			.apvpermymd(dto.apvpermymd())
+			.apvcancelymd(dto.apvcancelymd())
+			.trdstategbn(dto.trdstategbn())
+			.trdstatenm(dto.trdstatenm())
+			.dtlstategbn(dto.dtlstategbn())
+			.dtlstatenm(dto.dtlstatenm())
+			.dcbymd(dto.dcbymd())
+			.clgstdt(dto.clgstdt())
+			.clgenddt(dto.clgenddt())
+			.ropnymd(dto.ropnymd())
+			.sitetel(dto.sitetel())
+			.sitearea(dto.sitearea())
+			.sitepostno(dto.sitepostno())
+			.sitewhladdr(dto.sitewhladdr())
+			.rdnwhladdr(dto.rdnwhladdr())
+			.rdnpostno(dto.rdnpostno())
+			.bplcnm(dto.bplcnm())
+			.lastmodts(dto.lastmodts())
+			.updategbn(dto.updategbn())
+			.updatedt(dto.updatedt())
+			.uptaenm(dto.uptaenm())
+			.x(dto.x())
+			.y(dto.y())
+			.sntuptaenm(dto.sntuptaenm())
+			.maneipcnt(dto.maneipcnt())
+			.wmeipcnt(dto.wmeipcnt())
+			.trdpjubnsenm(dto.trdpjubnsenm())
+			.lvsenm(dto.lvsenm())
+			.wtrsplyfacilsenm(dto.wtrsplyfacilsenm())
+			.totepnum(dto.totepnum())
+			.hoffepcnt(dto.hoffepcnt())
+			.fctyowkepcnt(dto.fctyowkepcnt())
+			.fctysiljobepcnt(dto.fctysiljobepcnt())
+			.fctypdtjobepcnt(dto.fctypdtjobepcnt())
+			.bdngownsenm(dto.bdngownsenm())
+			.isream(dto.isream())
+			.monam(dto.monam())
+			.multusnupsoyn(dto.multusnupsoyn())
+			.faciltotscp(dto.faciltotscp())
+			.jtupsoasgnno(dto.jtupsoasgnno())
+			.jtupsomainedf(dto.jtupsomainedf())
+			.homepage(dto.homepage())
+			.hash(calculateHash())
+			.build();
+	}
+
+	private static String calculateHash() {
+		// TODO: SeoulRestaurantDto의 모든 필드에 대한 해시값 구하기
+		return null;
+	}
+}

--- a/src/main/java/oz/yamyam_map/batch/dto/SeoulRestaurantApiData.java
+++ b/src/main/java/oz/yamyam_map/batch/dto/SeoulRestaurantApiData.java
@@ -1,0 +1,14 @@
+package oz.yamyam_map.batch.dto;
+
+import java.util.List;
+
+import javax.xml.transform.Result;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record SeoulRestaurantApiData(
+	@JsonProperty("list_total_count") int totalCount,
+	@JsonProperty("RESULT") SeoulRestaurantApiResult result,
+	@JsonProperty("row") List<SeoulRestaurantDto> rows
+) {
+}

--- a/src/main/java/oz/yamyam_map/batch/dto/SeoulRestaurantApiResponse.java
+++ b/src/main/java/oz/yamyam_map/batch/dto/SeoulRestaurantApiResponse.java
@@ -1,0 +1,9 @@
+package oz.yamyam_map.batch.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record SeoulRestaurantApiResponse(
+	@JsonProperty("LOCALDATA_072404")
+	SeoulRestaurantApiData data
+) {
+}

--- a/src/main/java/oz/yamyam_map/batch/dto/SeoulRestaurantApiResult.java
+++ b/src/main/java/oz/yamyam_map/batch/dto/SeoulRestaurantApiResult.java
@@ -1,0 +1,9 @@
+package oz.yamyam_map.batch.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record SeoulRestaurantApiResult(
+	@JsonProperty("CODE") String code,
+	@JsonProperty("MESSAGE") String message
+) {
+}

--- a/src/main/java/oz/yamyam_map/batch/dto/SeoulRestaurantDto.java
+++ b/src/main/java/oz/yamyam_map/batch/dto/SeoulRestaurantDto.java
@@ -1,0 +1,50 @@
+package oz.yamyam_map.batch.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record SeoulRestaurantDto(
+	@JsonProperty("OPNSFTEAMCODE") String opnsfteamcode, // 개방자치단체코드
+	@JsonProperty("MGTNO") String mgtno, // 관리번호 PK
+	@JsonProperty("APVPERMYMD") String apvpermymd, // 인허가일자
+	@JsonProperty("APVCANCELYMD") String apvcancelymd, // 인허가취소일자
+	@JsonProperty("TRDSTATEGBN") String trdstategbn, // 영업상태코드
+	@JsonProperty("TRDSTATENM") String trdstatenm, // 영업상태명
+	@JsonProperty("DTLSTATEGBN") String dtlstategbn, // 상세영업상태코드
+	@JsonProperty("DTLSTATENM") String dtlstatenm, // 상세영업상태명
+	@JsonProperty("DCBYMD") String dcbymd, // 폐업일자
+	@JsonProperty("CLGSTDT") String clgstdt, // 휴업시작일자
+	@JsonProperty("CLGENDDT") String clgenddt, // 휴업종료일자
+	@JsonProperty("ROPNYMD") String ropnymd, // 재개업일자
+	@JsonProperty("SITETEL") String sitetel, // 전화번호
+	@JsonProperty("SITEAREA") String sitearea, // 소재지면적
+	@JsonProperty("SITEPOSTNO") String sitepostno, // 소재지우편번호
+	@JsonProperty("SITEWHLADDR") String sitewhladdr, // 지번주소
+	@JsonProperty("RDNWHLADDR") String rdnwhladdr, // 도로명주소
+	@JsonProperty("RDNPOSTNO") String rdnpostno, // 도로명우편번호
+	@JsonProperty("BPLCNM") String bplcnm, // 사업장명
+	@JsonProperty("LASTMODTS") String lastmodts, // 최종수정일자
+	@JsonProperty("UPDATEGBN") String updategbn, // 데이터갱신구분
+	@JsonProperty("UPDATEDT") String updatedt, // 데이터갱신일자
+	@JsonProperty("UPTAENM") String uptaenm, // 업태구분명
+	@JsonProperty("X") String x, // 좌표정보(X)
+	@JsonProperty("Y") String y, // 좌표정보(Y)
+	@JsonProperty("SNTUPTAENM") String sntuptaenm, // 위생업태명
+	@JsonProperty("MANEIPCNT") String maneipcnt, // 남성종사자수
+	@JsonProperty("WMEIPCNT") String wmeipcnt, // 여성종사자수
+	@JsonProperty("TRDPJUBNSENM") String trdpjubnsenm, // 영업장주변구분명
+	@JsonProperty("LVSENM") String lvsenm, // 등급구분명
+	@JsonProperty("WTRSPLYFACILSENM") String wtrsplyfacilsenm, // 급수시설구분명
+	@JsonProperty("TOTEPNUM") String totepnum, // 총인원
+	@JsonProperty("HOFFEPCNT") String hoffepcnt, // 본사종업원수
+	@JsonProperty("FCTYOWKEPCNT") String fctyowkepcnt, // 공장사무직종업원수
+	@JsonProperty("FCTYSILJOBEPCNT") String fctysiljobepcnt, // 공장판매직종업원수
+	@JsonProperty("FCTYPDTJOBEPCNT") String fctypdtjobepcnt, // 공장생산직종업원수
+	@JsonProperty("BDNGOWNSENM") String bdngownsenm, // 건물소유구분명
+	@JsonProperty("ISREAM") String isream, // 보증액
+	@JsonProperty("MONAM") String monam, // 월세액
+	@JsonProperty("MULTUSNUPSOYN") String multusnupsoyn, // 다중이용업소여부
+	@JsonProperty("FACILTOTSCP") String faciltotscp, // 시설총규모
+	@JsonProperty("JTUPSOASGNNO") String jtupsoasgnno, // 전통업소지정번호
+	@JsonProperty("JTUPSOMAINEDF") String jtupsomainedf, // 전통업소주된음식
+	@JsonProperty("HOMEPAGE") String homepage // 홈페이지
+) {}

--- a/src/main/java/oz/yamyam_map/batch/processor/RowSeoulDataProcessor.java
+++ b/src/main/java/oz/yamyam_map/batch/processor/RowSeoulDataProcessor.java
@@ -1,0 +1,23 @@
+package oz.yamyam_map.batch.processor;
+
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import oz.yamyam_map.batch.domain.RowSeoulRestaurant;
+import oz.yamyam_map.batch.dto.SeoulRestaurantDto;
+import oz.yamyam_map.batch.repository.RowSeoulRestaurantRepository;
+
+@Component
+@RequiredArgsConstructor
+public class RowSeoulDataProcessor implements ItemProcessor<SeoulRestaurantDto, RowSeoulRestaurant> {
+
+	private final RowSeoulRestaurantRepository rowSeoulRestaurantRepository;
+
+	@Override
+	public RowSeoulRestaurant process(SeoulRestaurantDto item) throws Exception {
+		// TODO: 기존 row table을 조회한 뒤 변경/추가가 발생했는지 확인 (기존과 그대로라면 null을 반환하면 skip)
+		// TODO: SeoulRestaurantDto를 RowSeoulRestaurant로 변환
+		return null;
+	}
+}

--- a/src/main/java/oz/yamyam_map/batch/processor/SeoulDataProcessor.java
+++ b/src/main/java/oz/yamyam_map/batch/processor/SeoulDataProcessor.java
@@ -1,0 +1,23 @@
+package oz.yamyam_map.batch.processor;
+
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import oz.yamyam_map.batch.domain.RowSeoulRestaurant;
+import oz.yamyam_map.module.restaurant.entity.Restaurant;
+import oz.yamyam_map.module.restaurant.repository.RestaurantRepository;
+
+@Component
+@RequiredArgsConstructor
+public class SeoulDataProcessor implements ItemProcessor<RowSeoulRestaurant, Restaurant> {
+
+	private final RestaurantRepository rowSeoulRestaurantRepository;
+
+	@Override
+	public Restaurant process(RowSeoulRestaurant item) {
+		// TODO: 데이터 전처리 작업 (폐업인 경우 기존 데이터 삭제, 업태 구분 설정, 위/경도 설정, 주소 설정, 시군구 매핑 등..)
+		// TODO: RowSeoulRestaurant Restaurant 변환
+		return null;
+	}
+}

--- a/src/main/java/oz/yamyam_map/batch/reader/RowSeoulDataApiReader.java
+++ b/src/main/java/oz/yamyam_map/batch/reader/RowSeoulDataApiReader.java
@@ -1,0 +1,53 @@
+package oz.yamyam_map.batch.reader;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+
+import org.springframework.batch.item.ItemReader;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import oz.yamyam_map.batch.dto.SeoulRestaurantDto;
+import oz.yamyam_map.batch.service.SeoulRestaurantApiService;
+
+@Component
+@RequiredArgsConstructor
+public class RowSeoulDataApiReader implements ItemReader<SeoulRestaurantDto> {
+	private static final int MAX_REQUEST_SIZE = 1000; // 서울 음식점 데이터는 한번에 1,000개만 요청 가능
+
+	private final SeoulRestaurantApiService seoulRestaurantApiService;
+
+	private int offset = 1;
+	private boolean hasNext = true;
+	private Queue<SeoulRestaurantDto> cache = new LinkedList<>();
+
+	/**
+	 * 네트워크 요청을 최대한 줄이기 위해, 미리 1000개의 데이터를 불러와 캐시한 뒤,
+	 * 캐시된 데이터를 하나씩 반환! 캐시가 소비되면 다음 데이터부터 다시 1000개 요청!
+	 */
+	@Override
+	public SeoulRestaurantDto read() {
+		if (cache.isEmpty()) { // 캐시된 데이터가 모두 소비됐으면, 다음 데이터를 불러옴
+			loadData();
+		}
+
+		if (!hasNext && cache.isEmpty()) { // 더 이상 데이터가 없으면 null 반환
+			return null;
+		}
+
+		return cache.poll(); // 캐시에서 데이터를 1개 소비
+	}
+
+	private void loadData() {
+		List<SeoulRestaurantDto> data = seoulRestaurantApiService.getRestaurants(offset, MAX_REQUEST_SIZE);
+
+		if (data.isEmpty()) { // 받은 데이터가 비어있다면 더 이상 데이터가 없음을 표시 (모든 데이터를 처리)
+			hasNext = false;
+			return;
+		}
+
+		cache = new LinkedList<>(data);
+		offset += MAX_REQUEST_SIZE;
+	}
+}

--- a/src/main/java/oz/yamyam_map/batch/reader/RowSeoulDataDbReader.java
+++ b/src/main/java/oz/yamyam_map/batch/reader/RowSeoulDataDbReader.java
@@ -1,0 +1,43 @@
+package oz.yamyam_map.batch.reader;
+
+import static java.util.Objects.*;
+
+import java.time.LocalDate;
+import java.util.Iterator;
+import java.util.List;
+
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import oz.yamyam_map.batch.domain.RowSeoulRestaurant;
+import oz.yamyam_map.batch.repository.RowSeoulRestaurantRepository;
+
+@Component
+@StepScope
+public class RowSeoulDataDbReader implements ItemReader<RowSeoulRestaurant> {
+
+	private final RowSeoulRestaurantRepository restaurantRepository;
+	private Iterator<RowSeoulRestaurant> rowSeoulRestaurantIterator;
+
+	/**
+	 * 업데이트 날짜가 jobParameters의 date와 같으면 변경/추가된 데이터이므로 처리 대상!
+	 * 참고) 서울 음식점 관련 데이터 파이프라인은 하루에 딱 1번 발생
+	 */
+	public RowSeoulDataDbReader(RowSeoulRestaurantRepository billingDataRepository,
+		@Value("#{jobParameters['data']}") LocalDate date) {
+		this.restaurantRepository = billingDataRepository;
+		List<RowSeoulRestaurant> billingDataList = restaurantRepository.findAllByUpdatedAt(date);
+		this.rowSeoulRestaurantIterator = billingDataList.iterator();
+	}
+
+	@Override
+	public RowSeoulRestaurant read() {
+		if (nonNull(rowSeoulRestaurantIterator) && rowSeoulRestaurantIterator.hasNext()) {
+			return rowSeoulRestaurantIterator.next();
+		} else {
+			return null;
+		}
+	}
+}

--- a/src/main/java/oz/yamyam_map/batch/repository/RowSeoulRestaurantRepository.java
+++ b/src/main/java/oz/yamyam_map/batch/repository/RowSeoulRestaurantRepository.java
@@ -1,0 +1,12 @@
+package oz.yamyam_map.batch.repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import oz.yamyam_map.batch.domain.RowSeoulRestaurant;
+
+public interface RowSeoulRestaurantRepository extends JpaRepository<RowSeoulRestaurant, Long> {
+	List<RowSeoulRestaurant> findAllByUpdatedAt(LocalDate updatedAt);
+}

--- a/src/main/java/oz/yamyam_map/batch/service/SeoulRestaurantApiService.java
+++ b/src/main/java/oz/yamyam_map/batch/service/SeoulRestaurantApiService.java
@@ -1,0 +1,21 @@
+package oz.yamyam_map.batch.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import oz.yamyam_map.batch.dto.SeoulRestaurantDto;
+
+@Component
+public class SeoulRestaurantApiService {
+
+	public List<SeoulRestaurantDto> getRestaurants(int offset, int limit) {
+		/**
+		 * TODO: HTTP 요청을 보내고, 결과를 SeoulRestaurantDto 리스트로 변환
+		 *  - GET http://openapi.seoul.go.kr:8088/{개발자키}/json/LOCALDATA_072404/{start}/{end}/
+		 *  - offset이 데이터 범위를 넘어설 경우 json으로 파싱이 안될 것임 (예외를 잡아서 처리하거나 다른 추가 로직 필요)
+		 *  - http 요청 시 start부터 end까지의 데이터를 가져옴 (offset/limit가 아님으로 주의!)
+		 */
+		return List.of();
+	}
+}

--- a/src/main/java/oz/yamyam_map/batch/writer/RowSeoulDataWriter.java
+++ b/src/main/java/oz/yamyam_map/batch/writer/RowSeoulDataWriter.java
@@ -1,0 +1,24 @@
+package oz.yamyam_map.batch.writer;
+
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import oz.yamyam_map.batch.domain.RowSeoulRestaurant;
+import oz.yamyam_map.batch.repository.RowSeoulRestaurantRepository;
+
+@Component
+@RequiredArgsConstructor
+public class RowSeoulDataWriter implements ItemWriter<RowSeoulRestaurant> {
+
+	private final RowSeoulRestaurantRepository rowSeoulRestaurantRepository;
+
+	/**
+	 * chunk개의 데이터가 처리되면 한번에 row_seoul_restaunt 테이블로 write
+	 */
+	@Override
+	public void write(Chunk<? extends RowSeoulRestaurant> chunk) {
+		rowSeoulRestaurantRepository.saveAll(chunk);
+	}
+}

--- a/src/main/java/oz/yamyam_map/batch/writer/SeoulDataWriter.java
+++ b/src/main/java/oz/yamyam_map/batch/writer/SeoulDataWriter.java
@@ -1,0 +1,24 @@
+package oz.yamyam_map.batch.writer;
+
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import oz.yamyam_map.module.restaurant.entity.Restaurant;
+import oz.yamyam_map.module.restaurant.repository.RestaurantRepository;
+
+@Component
+@RequiredArgsConstructor
+public class SeoulDataWriter implements ItemWriter<Restaurant> {
+
+	private final RestaurantRepository restaurantRepository;
+
+	/**
+	 * chunk개의 데이터가 처리되면 한번에 restaurant 테이블로 write
+	 */
+	@Override
+	public void write(Chunk<? extends Restaurant> chunk) throws Exception {
+		restaurantRepository.saveAll(chunk);
+	}
+}

--- a/src/main/resources/application-template.yml
+++ b/src/main/resources/application-template.yml
@@ -21,6 +21,10 @@ spring:
         format_sql: true
         show_sql: true
 
+  batch:
+    job:
+      enabled: false # 애플리케이션 실행 시 자동으로 Job이 실행되지 않도록 설정
+
 jwt:
   secret: ${JWT_SECRET}
   expiration: 3600000  # 1 hour in milliseconds

--- a/src/main/resources/application-template.yml
+++ b/src/main/resources/application-template.yml
@@ -29,6 +29,11 @@ jwt:
   secret: ${JWT_SECRET}
   expiration: 3600000  # 1 hour in milliseconds
 
+batch:
+  seoul:
+    auth_key: ${AUTH_KEY}
+    chunk_size: 100
+
 logging:
   level:
     root: INFO


### PR DESCRIPTION
## 🎟️ 관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #33 

## 👩‍💻 구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- [x] 스프링 배치 의존성 추가
- [x] OpenApi HTTP 요청을 위한 응답 DTO 생성(`batch/dto/*`) 
- [x] 서울시 데이터 파이프라인을 위한 Job 생성 및 하위 Step 생성
- [x] 각 Step에 필요한 커스텀 Reader, Processor, Writer 생성

#### 배치 작업 처음 보신 분들도 있을 것 같아서, 플로우차트 공유합니당!
![스크린샷 2024-08-31 20 07 15](https://github.com/user-attachments/assets/12473549-97d4-4c73-8032-12c1114c7b6d)
(그리고 배치 작업 상태를 저장하기 위해 DB에 메타데이터 테이블이 많이 생깁니다! 뭐가 많이 생겨도 무시해 주세요..)

## 💬 코멘트
<!-- PR 올리면서 팀원들에게 공유할 사항 및 이슈가 있다면 적어주세요!-->
- `batch/dto/*` 하위에 있는 엄청난 양의 코드는 HTTP 응답을 객체로 변환하기 위해 필요한 dto라 가볍게 보고 넘겨주시면 됩니다!
- 전반적인 구조를 잡은 코드이고 세부적인 구현이 필요한 부분은 주석 처리(ex. `TODO: 블라블라`)했습니다!
- 작업 실패 시 처리(ex. 로깅, 재시도) 및 스케쥴러 설정은 추후 추가할 생각입니다!
- 혹시 스프링 배치가 궁금하시다면 [이 링크](
https://spring.academy/courses/building-a-batch-application-with-spring-batch) 추천 드려요!

## 💭 고려한 점
- 경기도 데이터의 경우, unique 필드가 없기 때문에 해당 데이터가 변경이 된건지 새로 생성된 것인지 알 수 없다는 단점이 있었습니다. 그래서 일단 unique한 필드가 있는 서울시 데이터만 처리하기로 결정했습니다. (경기도는 추후 여유가 되면 조금 더 고민을 해봐야 할 것 같아요😭)
- row data에 변경이 발생했는지 빠르게 확인하기 위해 모든 필드에 대해 해싱한 해시값을 row_table 필드로 추가했습니다! (이렇게 하면 전체 필드의 비교없이 해시값 만으로 변경여부를 확인할 수 있습니다!)
- 변경된 row_data를 표시하기 위해 row_table 컬럼에 flag를 둘려고 했는데요! 생각해보니 해당 데이터가 이번 배치에 업데이트가 되었다고 표시하면, 다음 배치에서 해당 데이터가 업데이트가 되지 않았더라도 기존 `Update` 필드를 `Not_Update`로 바꿔야 해서, `이전에 변경된 데이터 + 오늘 변경된 데이터`에 대한 쓰기 작업이 발생할 것 같더라구요 (얘가 없으면 변경된 데이터만 쓰면 되는데 말이죠..) 그래서 해당 flag를 두지 않고, updatedAt이 오늘 날짜인 경우에만 데이터가 변경된 것으로 간주하고 Step 2 작업에서 처리하도록 했습니다!😉
- 배치 애플리케이션은 추후 별로의 애플리케이션으로 모듈 분리가 될 수 있기 떄문에 패키지를 따로 분리했습니다!