### PR TITLE
feat: 맛집 상세 정보 API 고도화 작업

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,9 @@ dependencies {
     // Hibernate Spatial
     implementation 'org.hibernate.orm:hibernate-spatial:6.5.2.Final'
 
+    // localdatetime 처리
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.3'
+
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/oz/yamyam_map/common/entity/BaseEntity.java
+++ b/src/main/java/oz/yamyam_map/common/entity/BaseEntity.java
@@ -7,6 +7,10 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
@@ -20,11 +24,15 @@ public abstract class BaseEntity {
 	@Column(nullable = false, updatable = false)
 	@CreatedDate
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+	@JsonSerialize(using = LocalDateTimeSerializer.class)
+	@JsonDeserialize(using = LocalDateTimeDeserializer.class)
 	private LocalDateTime createdAt;
 
 	@Column(nullable = false)
 	@LastModifiedDate
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+	@JsonSerialize(using = LocalDateTimeSerializer.class)
+	@JsonDeserialize(using = LocalDateTimeDeserializer.class)
 	private LocalDateTime updatedAt;
 
 }

--- a/src/main/java/oz/yamyam_map/common/util/GeoUtils.java
+++ b/src/main/java/oz/yamyam_map/common/util/GeoUtils.java
@@ -8,6 +8,10 @@ import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.PrecisionModel;
 
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 
@@ -28,7 +32,6 @@ public class GeoUtils {
 		return point;
 	}
 
-
 	/**
 	 * 위, 경도 소수점 6자리만 들어가도록 설정하는 메서드
 	 **/
@@ -46,6 +49,23 @@ public class GeoUtils {
 			gen.writeNumberField("x", roundToSixDecimals(value.getX()));
 			gen.writeNumberField("y", roundToSixDecimals(value.getY()));
 			gen.writeEndObject();
+		}
+	}
+
+	/**
+	 * JSON을 Point 객체로 역직렬화하는 메서드 (redis에서 데이터를 가져올 때 필요)
+	 **/
+	public static class PointDeserializer extends JsonDeserializer<Point> {
+		private final GeometryFactory geometryFactory = new GeometryFactory();
+
+		@Override
+		public Point deserialize(JsonParser jsonParser, DeserializationContext context) throws IOException {
+			JsonNode node = jsonParser.getCodec().readTree(jsonParser);
+
+			double x = node.get("x").asDouble();
+			double y = node.get("y").asDouble();
+
+			return geometryFactory.createPoint(new Coordinate(x, y));
 		}
 	}
 }

--- a/src/main/java/oz/yamyam_map/core/config/RedisConfig.java
+++ b/src/main/java/oz/yamyam_map/core/config/RedisConfig.java
@@ -1,0 +1,32 @@
+package oz.yamyam_map.core.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+	@Value("${spring.data.redis.host}")
+	private String redisHost;
+	@Value("${spring.data.redis.port}")
+	private int redisPort;
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		return new LettuceConnectionFactory(redisHost, redisPort);
+	}
+
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate() {
+		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(redisConnectionFactory());
+		redisTemplate.setKeySerializer(new StringRedisSerializer()); // 직렬화 작업
+		redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+		return redisTemplate;
+	}
+}

--- a/src/main/java/oz/yamyam_map/core/config/RedisConfig.java
+++ b/src/main/java/oz/yamyam_map/core/config/RedisConfig.java
@@ -1,5 +1,6 @@
 package oz.yamyam_map.core.config;
 
+import org.locationtech.jts.geom.Point;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -8,6 +9,11 @@ import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactor
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import oz.yamyam_map.common.util.GeoUtils;
 
 @Configuration
 public class RedisConfig {
@@ -22,11 +28,20 @@ public class RedisConfig {
 	}
 
 	@Bean
+	public ObjectMapper objectMapper() {
+		ObjectMapper mapper = new ObjectMapper();
+		SimpleModule module = new SimpleModule();
+		module.addSerializer(Point.class, new GeoUtils.PointSerializer());
+		mapper.registerModule(module);
+		return mapper;
+	}
+
+	@Bean
 	public RedisTemplate<String, Object> redisTemplate() {
 		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
 		redisTemplate.setConnectionFactory(redisConnectionFactory());
 		redisTemplate.setKeySerializer(new StringRedisSerializer()); // 직렬화 작업
-		redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+		redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper()));
 		return redisTemplate;
 	}
 }

--- a/src/main/java/oz/yamyam_map/module/restaurant/dto/response/RestaurantDetailRes.java
+++ b/src/main/java/oz/yamyam_map/module/restaurant/dto/response/RestaurantDetailRes.java
@@ -1,5 +1,7 @@
 package oz.yamyam_map.module.restaurant.dto.response;
 
+import org.locationtech.jts.geom.Point;
+
 import lombok.Builder;
 import lombok.Getter;
 import oz.yamyam_map.common.enums.RestaurantType;
@@ -13,8 +15,7 @@ public class RestaurantDetailRes {
 	private String name;
 	private RestaurantType businessType;
 	private String phoneNumber;
-	private double pointX;
-	private double pointY;
+	private Point location;
 	private String oldAddressFull;
 	private String roadAddressFull;
 	private ReviewRating reviewRating;
@@ -25,8 +26,7 @@ public class RestaurantDetailRes {
 			.name(restaurant.getName())
 			.businessType(restaurant.getBusinessType())
 			.phoneNumber(restaurant.getPhoneNumber())
-			.pointX(restaurant.getLocation().getX()) // Point의 x 좌표
-			.pointY(restaurant.getLocation().getY()) // Point의 y 좌표
+			.location(restaurant.getLocation())
 			.oldAddressFull(restaurant.getOldAddressFull())
 			.roadAddressFull(restaurant.getRoadAddressFull())
 			.reviewRating(restaurant.getReviewRating())

--- a/src/main/java/oz/yamyam_map/module/restaurant/entity/Restaurant.java
+++ b/src/main/java/oz/yamyam_map/module/restaurant/entity/Restaurant.java
@@ -2,6 +2,8 @@ package oz.yamyam_map.module.restaurant.entity;
 
 import org.locationtech.jts.geom.Point;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -17,6 +19,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import oz.yamyam_map.common.entity.BaseEntity;
 import oz.yamyam_map.common.enums.RestaurantType;
+import oz.yamyam_map.common.util.GeoUtils;
 
 @Entity
 @Getter
@@ -39,11 +42,12 @@ public class Restaurant extends BaseEntity {
 	private String phoneNumber;
 
 	@Column(nullable = false, columnDefinition = "GEOMETRY")
+	@JsonDeserialize(using = GeoUtils.PointDeserializer.class)
 	private Point location;
 
-	private String OldAddressFull;
+	private String oldAddressFull;
 
-	private String RoadAddressFull;
+	private String roadAddressFull;
 
 	@Embedded
 	private ReviewRating reviewRating; // 리뷰 평점 데이터를 위한 VO

--- a/src/main/java/oz/yamyam_map/module/restaurant/entity/ReviewRating.java
+++ b/src/main/java/oz/yamyam_map/module/restaurant/entity/ReviewRating.java
@@ -1,8 +1,10 @@
 package oz.yamyam_map.module.restaurant.entity;
 
 import jakarta.persistence.Embeddable;
+import lombok.Getter;
 
 @Embeddable
+@Getter
 public class ReviewRating {
 
 	private Long totalReviews;

--- a/src/main/java/oz/yamyam_map/module/restaurant/service/RestaurantService.java
+++ b/src/main/java/oz/yamyam_map/module/restaurant/service/RestaurantService.java
@@ -1,9 +1,13 @@
 package oz.yamyam_map.module.restaurant.service;
 
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import oz.yamyam_map.common.code.StatusCode;
 import oz.yamyam_map.exception.custom.BusinessException;
 import oz.yamyam_map.exception.custom.DataNotFoundException;
@@ -19,10 +23,14 @@ import oz.yamyam_map.module.restaurant.repository.ReviewRepository;
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
+@Slf4j
 public class RestaurantService {
+	private static final String CACHE_PREFIX = "restaurant:";
+	private static final int TTL = 24;
 	private final ReviewRepository reviewRepository;
 	private final MemberRepository memberRepository;
 	private final RestaurantRepository restaurantRepository;
+	private final RedisTemplate<String, Object> redisTemplate;
 
 	@Transactional
 	public void uploadReview(Long memberId, Long restaurantId, ReviewUploadReq req) {
@@ -40,8 +48,24 @@ public class RestaurantService {
 	}
 
 	public RestaurantDetailRes getRestaurantDetails(Long restaurantId) {
+		String cacheKey = CACHE_PREFIX + restaurantId;
+		Restaurant cachedRestaurant = (Restaurant)redisTemplate.opsForValue().get(cacheKey);
+
+		if (cachedRestaurant != null) {
+			log.info("{}번 맛집을 캐싱합니다.", restaurantId);
+			return RestaurantDetailRes.from(cachedRestaurant);
+		}
+
+		log.info("캐시에 존재하지 않아 DB에서 조회합니다.");
 		Restaurant restaurant = restaurantRepository.findById(restaurantId)
 			.orElseThrow(() -> new DataNotFoundException(StatusCode.RESTAURANT_NOT_FOUND));
+
+		if (restaurant.getReviewRating().getTotalReviews() >= 10) {
+			log.info("{}번 맛집을 캐시에 저장 작업을 시작합니다.", restaurantId);
+			redisTemplate.opsForValue().set(cacheKey, restaurant, TTL, TimeUnit.HOURS);
+			log.info("{}번 맛집을 캐시에 저장 작업을 완료했습니다.", restaurantId);
+		}
+
 		return RestaurantDetailRes.from(restaurant);
 	}
 }


### PR DESCRIPTION
## 🎟️ 관련 이슈
Fixes #38 

## 👩‍💻 구현 내용
- [ ] `RedisConfig` 파일 작성
- [ ] `Point`타입 `역직렬화` 정적 클래스 및 메소드 작성
- [ ] **리뷰 개수 10개 이상**인 맛집 데이터 `redis`에 저장(24시간 동안 유지)

## 💬 코멘트
1. `Point` 객체를 직렬화, 역직렬화 하고 `redis`에 저장, 반환 시 반영하는 부분을 개발 시간의 90% 정도 할애한 것 같네요..
직렬화는 도은님께서 작성해주신 클래스 사용했습니다!(감사해요🤗)

**✅ 직렬화**
캐시에 저장할 때 `Point`객체를 `Json`으로 바꿔주어야 했습니다. 그래서 `RedisConfig`파일에서
```java
@Bean
public ObjectMapper objectMapper() {
        ObjectMapper mapper = new ObjectMapper();
        SimpleModule module = new SimpleModule();
        module.addSerializer(Point.class, new GeoUtils.PointSerializer());
        mapper.registerModule(module);
        return mapper;
}
```
`objectMapper`를 사용해서 `Point`객체를 직렬화하는 클래스를 넣어주고 반영했습니다.

**✅ 역직렬화**
캐시에 저장된 `Restaurant`타입의 맛집 데이터를 가져올 때 `Point`객체를 역직렬화 해주어야 했습니다.
```java
/**
* JSON을 Point 객체로 역직렬화하는 메서드 (redis에서 데이터를 가져올 때 필요)
**/
public static class PointDeserializer extends JsonDeserializer<Point> {
// 코드가 길어서 클래스만 첨부했습니다.
// 코드는 PointDeserializer 클래스에서 보실 수 있어요!
}
```
```java
@Column(nullable = false, columnDefinition = "GEOMETRY")
@JsonDeserialize(using = GeoUtils.PointDeserializer.class)
private Point location;
```
`@JsonDeserialize` 어노테이션을 사용해서 위에서 설정해준 역직렬화 클래스를 적용해 주었습니다.

2. `getRestaurantDetails()` 메소드에 캐싱 처리를 주석으로 작성할까 하다가 제가 원래 주석을 잘 안 적기도 하고 + 작업하면서 쉽게 확인할 수 있게 하려고 `log.info(~~~)`로 작성했습니다!

3. 캐시를 사용했을 때 성능이 향상된다는 것을 테스트하기 위한 테스트 코드는 개인 과제 하면서 같이 진행해야 할 것 같습니다..!😥
## 💭 고려한 점
1. 어떤 기준으로 캐시에 저장할까 하다가 **리뷰 개수가 10개 이상**인 맛집을 기준으로 저장했습니다. 사실 10이라는 숫자는 큰 의미 없이 정해서.. 혹시 수정이 필요하면 말씀해주세요!
2. 캐시에 저장할 때 **TTL**을 **24시간**(하루)로 설정했습니다. 매일 스케쥴러를 돌린다고 알아서 24시간으로 설정했는데 확신을 가지고 한 건 아니라서 피드백 부탁드립니다!
3. `Spring Boot Starter Redis`를 사용하는 경우, `redis`를 다룰 때 `RedisTemplate`과 `RedisRepository`를 사용한다고 하네요. 뭘 사용할까 하다가 [각 작업에 대해 특정 데이터 형식에 맞는 Serializer 및 Deserializer를 구성할 수 있다.](https://velog.io/@turtledev/Spring-Redis-Redis-Template%EA%B3%BC-Redis-Repository)라는 글을 보고 `RedisTemplate`으로 골랐습니다!